### PR TITLE
Improve client logging and JSON error handling

### DIFF
--- a/safie_mediafile/_client.py
+++ b/safie_mediafile/_client.py
@@ -1,6 +1,13 @@
-from typing import AsyncGenerator, Optional
+from typing import Any, AsyncGenerator, Optional
 import httpx
 from contextlib import asynccontextmanager
+import logging
+import time
+
+from safie_mediafile._exceptions import SafieAPIError, SafieMediaFileError
+
+
+logger = logging.getLogger(__name__)
 
 
 SAFIE_API_BASE_URL = "https://openapi.safie.link"
@@ -25,7 +32,7 @@ class SafieClient:
         self._client = client
         self._headers = {"Safie-API-Key": api_token}
 
-    async def get(self, path: str, **kwargs) -> httpx.Response:
+    async def get(self, path: str, **kwargs) -> Any:
         """
         Send GET request
 
@@ -34,15 +41,17 @@ class SafieClient:
             **kwargs: Request parameters
 
         Returns:
-            httpx.Response: Response
+            Any: Parsed JSON response
         """
         url = f"{self._base_url}{path}"
+        start_time = time.perf_counter()
         response = await self._client.get(url, headers=self._headers, **kwargs)
-        print(f"get response: {response.json()}")
+        elapsed = time.perf_counter() - start_time
+        logger.debug("GET %s -> %s in %.3fs", url, response.status_code, elapsed)
         response.raise_for_status()
-        return response
+        return self._parse_json_response(response)
 
-    async def post(self, path: str, **kwargs) -> httpx.Response:
+    async def post(self, path: str, **kwargs) -> Any:
         """
         Send POST request
 
@@ -51,15 +60,17 @@ class SafieClient:
             **kwargs: Request parameters
 
         Returns:
-            httpx.Response: Response
+            Any: Parsed JSON response
         """
         url = f"{self._base_url}{path}"
+        start_time = time.perf_counter()
         response = await self._client.post(url, headers=self._headers, **kwargs)
-        print(f"post response: {response.json()}")
+        elapsed = time.perf_counter() - start_time
+        logger.debug("POST %s -> %s in %.3fs", url, response.status_code, elapsed)
         response.raise_for_status()
-        return response
+        return self._parse_json_response(response)
 
-    async def delete(self, path: str, **kwargs) -> httpx.Response:
+    async def delete(self, path: str, **kwargs) -> Any:
         """
         Send DELETE request
 
@@ -68,13 +79,15 @@ class SafieClient:
             **kwargs: Request parameters
 
         Returns:
-            httpx.Response: Response
+            Any: Parsed JSON response
         """
         url = f"{self._base_url}{path}"
+        start_time = time.perf_counter()
         response = await self._client.delete(url, headers=self._headers, **kwargs)
-        print(f"delete response: {response.status_code}")
+        elapsed = time.perf_counter() - start_time
+        logger.debug("DELETE %s -> %s in %.3fs", url, response.status_code, elapsed)
         response.raise_for_status()
-        return response
+        return self._parse_json_response(response)
 
     async def sync_stream(self, url: str, **kwargs) -> AsyncGenerator[bytes, None]:
         """
@@ -85,12 +98,38 @@ class SafieClient:
             **kwargs: Request parameters
 
         Returns:
-            httpx.Response: Response
+            AsyncGenerator[bytes, None]: Streaming response bytes
         """
-        async with self._client.stream("GET", url, headers=self._headers, **kwargs) as response:
-            response.raise_for_status()
-            async for chunk in response.aiter_bytes():
-                yield chunk
+        start_time = time.perf_counter()
+        logger.debug("STREAM GET %s starting", url)
+        try:
+            async with self._client.stream(
+                "GET", url, headers=self._headers, **kwargs
+            ) as response:
+                response.raise_for_status()
+                elapsed = time.perf_counter() - start_time
+                logger.debug(
+                    "STREAM GET %s -> %s in %.3fs", url, response.status_code, elapsed
+                )
+                async for chunk in response.aiter_bytes():
+                    yield chunk
+        except Exception as exc:
+            elapsed = time.perf_counter() - start_time
+            logger.debug("STREAM GET %s failed in %.3fs", url, elapsed)
+            raise SafieMediaFileError(f"Failed to stream from {url}: {exc}") from exc
+
+    def _parse_json_response(self, response: httpx.Response) -> Any:
+        try:
+            return response.json()
+        except Exception as exc:
+            content_summary = response.text
+            max_length = 200
+            if len(content_summary) > max_length:
+                content_summary = f"{content_summary[:max_length]}..."
+            message = (
+                f"Failed to parse JSON response from {response.url}: {content_summary}"
+            )
+            raise SafieAPIError(message, response.status_code, content_summary) from exc
 
 
 @asynccontextmanager

--- a/safie_mediafile/_endpoints/_device.py
+++ b/safie_mediafile/_endpoints/_device.py
@@ -26,8 +26,7 @@ class DeviceAPI:
             Dict[str, Any]: Device list information
         """
         params = {"offset": offset, "limit": limit}
-        response = await self._client.get("/v2/devices", params=params)
-        return response.json()
+        return await self._client.get("/v2/devices", params=params)
 
     async def find_device_by_serial(self, serial: str) -> Optional[str]:
         """

--- a/safie_mediafile/_endpoints/_mediafile.py
+++ b/safie_mediafile/_endpoints/_mediafile.py
@@ -34,10 +34,9 @@ class MediaFileAPI:
             "start": start_time.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
             "end": end_time.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
         }
-        response = await self._client.post(
+        result = await self._client.post(
             f"/v2/devices/{device_id}/media_files/requests", json=data
         )
-        result = response.json()
         return result["request_id"]
 
     async def list_mediafile_requests(self, device_id: str) -> list:
@@ -48,7 +47,7 @@ class MediaFileAPI:
             device_id: Device ID
         """
         response = await self._client.get(f"/v2/devices/{device_id}/media_files/requests")
-        return response.json()["list"]
+        return response["list"]
 
     async def delete_mediafile_request(self, device_id: str, request_id: str) -> None:
         """
@@ -71,10 +70,9 @@ class MediaFileAPI:
         Returns:
             dict: Media file status information
         """
-        response = await self._client.get(
+        return await self._client.get(
             f"/v2/devices/{device_id}/media_files/requests/{request_id}"
         )
-        return response.json()
 
     async def download_mediafile(self, url: str, file: BinaryIO):
         """


### PR DESCRIPTION
## Summary
- add debug logging for HTTP requests and streaming operations
- raise SafieAPIError with response summaries when JSON parsing fails after successful responses
- propagate parsed JSON from client methods to endpoint helpers and wrap streaming errors as SafieMediaFileError

## Testing
- python -m pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e750b20f083339fdc7057446a47ec)